### PR TITLE
allow compilation using later versions of java/maven + macOS compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <!-- project settings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- plug-in settings -->
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
     <!-- versions of common dependencies -->
     <slf4j.version>1.7.12</slf4j.version>
   </properties>
@@ -42,6 +42,11 @@
     </developer>
   </developers>
   <dependencies>
+    <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
+    </dependency>
     <dependency>
       <groupId>eu.clarin.sru.fcs</groupId>
       <artifactId>fcs-simple-endpoint</artifactId>
@@ -94,6 +99,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>2.8.1</version>
+        <configuration><source>7</source></configuration>
         <executions>
           <execution>
             <id>attach-javadoc</id>

--- a/src/main/java/se/gu/spraakbanken/fcs/endpoint/korp/KorpEndpointSearchEngine.java
+++ b/src/main/java/se/gu/spraakbanken/fcs/endpoint/korp/KorpEndpointSearchEngine.java
@@ -41,6 +41,7 @@ import eu.clarin.sru.server.SRUQueryParserRegistry;
 import eu.clarin.sru.server.SRURequest;
 import eu.clarin.sru.server.SRUScanResultSet;
 import eu.clarin.sru.server.SRUSearchResultSet;
+import eu.clarin.sru.server.SRUServer;
 import eu.clarin.sru.server.SRUServerConfig;
 import eu.clarin.sru.server.fcs.Constants;
 import eu.clarin.sru.server.fcs.DataView;

--- a/src/main/java/se/gu/spraakbanken/fcs/endpoint/korp/data/json/pojo/error/ERROR.java
+++ b/src/main/java/se/gu/spraakbanken/fcs/endpoint/korp/data/json/pojo/error/ERROR.java
@@ -1,4 +1,4 @@
-package se.gu.spraakbanken.fcs.endpoint.korp.data.json.pojo;
+package se.gu.spraakbanken.fcs.endpoint.korp.data.json.pojo.error;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -13,56 +13,56 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({
-	"ERROR",
-	"time"
+"type",
+"value"
 })
 
-public class Error {
-    @JsonProperty("ERROR")
-    private se.gu.spraakbanken.fcs.endpoint.korp.data.json.pojo.error.ERROR ERROR;
-    @JsonProperty("time")
-    private Double time;
+public class ERROR {
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("value")
+    private String value;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
     /**
      *
      * @return
-     * The ERROR
+     * The type
      */
-    @JsonProperty("ERROR")
-    public se.gu.spraakbanken.fcs.endpoint.korp.data.json.pojo.error.ERROR getERROR() {
-	return ERROR;
+    @JsonProperty("type")
+    public String getType() {
+	return type;
     }
 
     /**
      *
-     * @param ERROR
-     * The ERROR
+     * @param type
+     * The type
      */
-    @JsonProperty("ERROR")
-    public void setERROR(se.gu.spraakbanken.fcs.endpoint.korp.data.json.pojo.error.ERROR ERROR) {
-	this.ERROR = ERROR;
+    @JsonProperty("type")
+    public void setType(String type) {
+	this.type = type;
     }
 
     /**
      *
      * @return
-     * The time
+     * The value
      */
-    @JsonProperty("time")
-    public Double getTime() {
-	return time;
+    @JsonProperty("value")
+    public String getValue() {
+	return value;
     }
 
     /**
      *
-     * @param time
-     * The time
+     * @param value
+     * The value
      */
-    @JsonProperty("time")
-    public void setTime(Double time) {
-	this.time = time;
+    @JsonProperty("value")
+    public void setValue(String value) {
+	this.value = value;
     }
 
     @JsonAnyGetter
@@ -74,5 +74,4 @@ public class Error {
     public void setAdditionalProperty(String name, Object value) {
 	this.additionalProperties.put(name, value);
     }
-
 }

--- a/src/test/java/se/gu/spraakbanken/fcs/endpoint/korp/KorpEndpointSearchEngineTest.java
+++ b/src/test/java/se/gu/spraakbanken/fcs/endpoint/korp/KorpEndpointSearchEngineTest.java
@@ -337,7 +337,8 @@ public class KorpEndpointSearchEngineTest {
 	    xmlStreamWriter.flush();
 	    xmlStreamWriter.close();
 	} catch (Exception ex) {
-	    xmlStreamWriter.close();
+		// TODO: throwing an error that blocks compilation, unsure how to proceed
+	    //xmlStreamWriter.close();
 	}
 
 	System.out.println("getHits: " + queryRes.getHits());


### PR DESCRIPTION
Hi!

I'm working for the Centre for Language technology at the University of Copenhagen and have inherited some older code that branches out from this repository. I couldn't get the older code to compile using Java 13 and Maven 3.6.3 on macOS, so I attempted to compile this project instead to make sure it wasn't related to my predecessor's code changes.

It turns out that a few separate issues were blocking me:

1. In its current state, this won't compile on macOS for the simple reason that macOS doesn't support having filenames with the same name in different cases located in the same folder. The culprits were `Error.java` and `ERROR.java`. I've copied `ERROR.java` to a separate directory.
    - This is a file system incompatibility and suspect that it is also be present on many older versions of Windows. Git notifies you of this when you first clone the repository on a Mac.
    - Since only a single one of the two files can exist at a time, this effectively makes any change to the git repository itself completely impossible on a Mac. Changing branches is impossible because git is in an inconsistent state. Creating new branches is impossible for the same reason.
    - For this reason, it's also impossible for me to actually delete the conflicting file (`ERROR.java`) from this commit using a Mac. I suppose I could do it using arcane Git knowledge or by making the changes on a Linux system instead, but I leave that as an exercise to the reader.
    - This was also reported in https://github.com/clarin-eric/fcs-korp-endpoint/issues/1 back in 2017.
2. Later versions of Java (9+) don't include javax.annotation, so it needs to be added as a dependency.
3. Later versions of Maven don't support Java 1.6 as a compilation target, only 1.7+.
4. There was an error due to a missing import (`SRUServer`) in one of the files.
5. There was an error thrown in the catch part of a try-catch statement in one of the tests. I've commented it out as I was unsure how to proceed otherwise.